### PR TITLE
Fix: improve tracking accuracy 

### DIFF
--- a/watchers/src/report_client.rs
+++ b/watchers/src/report_client.rs
@@ -96,7 +96,7 @@ impl ReportClient {
             return Ok(());
         }
 
-        let interval_margin = self.config.poll_time_idle.as_secs_f64() + 1.0;
+        let interval_margin = self.config.poll_time_window.as_secs_f64() + 1.0;
         self.client
             .heartbeat(&self.active_window_bucket_name, &event, interval_margin)
             .await

--- a/watchers/src/report_client.rs
+++ b/watchers/src/report_client.rs
@@ -87,7 +87,8 @@ impl ReportClient {
         let event = AwEvent {
             id: None,
             timestamp: Utc::now(),
-            duration: Duration::zero(),
+            // Added one nano second to ensure the event is not filtered out by https://github.com/ActivityWatch/aw-webui/blob/cf74080d12ffd53d37c83e3e0eddaf952fe14a62/src/visualizations/VisTimeline.vue#L108
+            duration: Duration::from_std(self.config.poll_time_window).unwrap() + Duration::nanoseconds(1),
             data,
         };
 


### PR DESCRIPTION
Hi, thank you for making this extension! I recently noticed this, and it is especially dominant when I set a higher poll time: 
![image](https://github.com/2e3s/awatcher/assets/60573138/63c66a81-af67-456b-8446-feab34bf839d)

Upon investigation, it seems like the zero duration caused the issue. If window changes within one polling block, that entry will have a total time of zero, resulting in inaccuracies. 

This zero duration was used in other places such as web tracker. However, they hook onto events (such as tab changes) making the duration unknown to them when generating events. They were able to patch up the event time by sending two consecutive events: https://github.com/ActivityWatch/aw-watcher-web/blob/0b289c4208f308050979fc729a69cf0c57dd7d8f/src/eventPage.js#L58-L63

In our case, however, it is not necessary to store the previous event as we know approximately how long is each event. If you were to look at database closely, you will find that there's still minor inaccuracies as we used `await` after the timer fires. This is much minor and I'll be happy to take such a compromise. (it should be easy to fix it by removing the `await`, though we need to deal with duration computation more carefully).

Here's the result after the fix:

![image](https://github.com/2e3s/awatcher/assets/60573138/bddf0d8b-7da4-4292-b057-f15fb8b696ff)
