### PR TITLE
x11: send end of previous active window

### DIFF
--- a/watchers/src/watchers/x11_window.rs
+++ b/watchers/src/watchers/x11_window.rs
@@ -32,6 +32,10 @@ impl WindowWatcher {
                 r#"Changed window app_id="{}", title="{}", wm_instance="{}""#,
                 app_id, title, wm_instance
             );
+            client
+                .send_active_window_with_instance(&self.last_app_id, &self.last_title, Some(&self.last_wm_instance))
+                .await
+                .with_context(|| "Failed to send heartbeat for previous window")?;
             self.last_app_id = app_id.clone();
             self.last_title = title.clone();
             self.last_wm_instance = wm_instance.clone();


### PR DESCRIPTION
Fixes #29

I also adjusted the retry logic, since for some reason two consecutive calls to `ReportClient.send_active_window_with_instance` -> `aw_client_rust::AwClient.heartbeat` lead to `connection closed before message completed`. Waiting just 0.01 fixes this issue
