### PR TITLE
Update watchers priorities

### DIFF
--- a/watchers/src/watchers.rs
+++ b/watchers/src/watchers.rs
@@ -110,14 +110,14 @@ async fn filter_first_supported(
                 client,
                 "KWin window (script)"
             ));
-            watch!(create_watcher::<x11_window::WindowWatcher>(
-                client,
-                "X11 window"
-            ));
             #[cfg(feature = "gnome")]
             watch!(create_watcher::<gnome_window::WindowWatcher>(
                 client,
                 "Gnome window (extension)"
+            ));
+            watch!(create_watcher::<x11_window::WindowWatcher>(
+                client,
+                "X11 window"
             ));
         }
     };


### PR DESCRIPTION
Fixes #47 

Make extension watcher to take precedence over X11 window watcher when available. This would make Gnome extension be activated correctly, when using XWayland.