### PR TITLE
fix: prioritize GNOME/KDE watchers and add environment check for COSMIC

### DIFF
--- a/watchers/src/watchers.rs
+++ b/watchers/src/watchers.rs
@@ -99,6 +99,16 @@ async fn filter_first_supported(
             ));
         }
         WatcherType::ActiveWindow => {
+            #[cfg(feature = "gnome")]
+            watch!(create_watcher::<gnome_window::WindowWatcher>(
+                client,
+                "Gnome window (extension)"
+            ));
+            #[cfg(feature = "kwin_window")]
+            watch!(create_watcher::<kwin_window::WindowWatcher>(
+                client,
+                "KWin window (script)"
+            ));
             watch!(create_watcher::<
                 wl_foreign_toplevel_management::WindowWatcher,
             >(
@@ -111,17 +121,6 @@ async fn filter_first_supported(
                     "Cosmic Wayland window (cosmic-toplevel-info-unstable-v1)"
                 )
             );
-            // XWayland gives _NET_WM_NAME on some windows in KDE, but not on others
-            #[cfg(feature = "kwin_window")]
-            watch!(create_watcher::<kwin_window::WindowWatcher>(
-                client,
-                "KWin window (script)"
-            ));
-            #[cfg(feature = "gnome")]
-            watch!(create_watcher::<gnome_window::WindowWatcher>(
-                client,
-                "Gnome window (extension)"
-            ));
             watch!(create_watcher::<x11_window::WindowWatcher>(
                 client,
                 "X11 window"

--- a/watchers/src/watchers/wl_cosmic_toplevel_management.rs
+++ b/watchers/src/watchers/wl_cosmic_toplevel_management.rs
@@ -29,9 +29,20 @@ struct ToplevelState {
     sender: mpsc::Sender<WindowData>,
 }
 
+fn is_cosmic() -> bool {
+    if let Ok(de) = std::env::var("XDG_CURRENT_DESKTOP") {
+        de.to_lowercase().contains("cosmic")
+    } else {
+        false
+    }
+}
+
 fn initialize_state(
     sender: mpsc::Sender<WindowData>,
 ) -> anyhow::Result<(ToplevelState, EventQueue<ToplevelState>)> {
+    if !is_cosmic() {
+        return Err(anyhow!("Not in COSMIC environment"));
+    }
     let conn = Connection::connect_to_env()?;
     let (globals, event_queue) = registry_queue_init(&conn)?;
     let qh: QueueHandle<ToplevelState> = event_queue.handle();


### PR DESCRIPTION
I'm on Ubuntu 25.10 with wayland and I kept having this error:

[2026-02-18 18:46:02.979828 DEBUG watchers::watchers] Watcher "Wayland idle (ext-idle-notify-v1)" cannot run: the requested global was not found in the registry
[2026-02-18 18:46:02.979998 DEBUG watchers::watchers] Watcher "Wayland idle (KDE)" cannot run: the requested global was not found in the registry
[2026-02-18 18:46:02.980326 DEBUG watchers::watchers] Watcher "X11 idle (screensaver)" cannot run: Unsupported extension
[2026-02-18 18:46:02.980333 DEBUG watchers::watchers::gnome_wayland] Gnome Wayland detected
[2026-02-18 18:46:02.980566 DEBUG watchers::watchers] Watcher "Wayland window (wlr-foreign-toplevel-management-unstable-v1)" cannot run: the requested global was not found in the registry
[2026-02-18 18:46:02.980598 INFO watchers::watchers] Selected watcher: Cosmic Wayland window (cosmic-toplevel-info-unstable-v1)
[2026-02-18 18:46:02.980602 INFO watchers::watchers] Starting active window watcher
[2026-02-18 18:46:02.980905 ERROR watchers::watchers::wl_cosmic_toplevel_management] Wayland thread failed: Required COSMIC toplevel protocols not found

I have no merit in this as Gemini proposed this fix to reorder the watcher priority to make it work with gnome, wayland and the focused window dbus extension. **Someone on COSMIC might have to make sure it still works.**

I've decided to push this fix as it might help someone else having the same problem. Now the application works number one for me.