### PR TITLE
Be more specific when writing kwin script fails

### DIFF
--- a/watchers/src/watchers/kwin_window.rs
+++ b/watchers/src/watchers/kwin_window.rs
@@ -33,7 +33,8 @@ impl KWinScript {
 
     async fn load(&mut self) -> anyhow::Result<()> {
         let path = temp_dir().join("kwin_window.js");
-        std::fs::write(&path, KWIN_SCRIPT).expect("Failed to write kwin script to temporary directory");
+        std::fs::write(&path, KWIN_SCRIPT)
+            .with_context(|| format!("Failed to write kwin script to {}", path.display()))?;
 
         let number = self.get_registered_number(&path).await?;
         let result = self.start(number).await;

--- a/watchers/src/watchers/kwin_window.rs
+++ b/watchers/src/watchers/kwin_window.rs
@@ -33,7 +33,7 @@ impl KWinScript {
 
     async fn load(&mut self) -> anyhow::Result<()> {
         let path = temp_dir().join("kwin_window.js");
-        std::fs::write(&path, KWIN_SCRIPT).unwrap();
+        std::fs::write(&path, KWIN_SCRIPT).expect("Failed to write kwin script to temporary directory");
 
         let number = self.get_registered_number(&path).await?;
         let result = self.start(number).await;


### PR DESCRIPTION
Makes it clearer to the user what is wrong.

Disclaimer: I had an issue with some missing dev dependencies, so this change has not been tested